### PR TITLE
Remove object lifetime casts

### DIFF
--- a/src/jit/mod.rs
+++ b/src/jit/mod.rs
@@ -310,11 +310,15 @@ impl Vm {
         let program = self.program.as_function();
 
         let mut out_wrapper = WriteWrapper {
-            write: output as *const dyn Write as *mut dyn Write,
+            write: unsafe {
+                std::mem::transmute::<*mut (dyn Write + '_), *mut (dyn Write + 'static)>(output)
+            },
         };
 
         let mut in_wrapper = ReadWrapper {
-            read: input as *const dyn Read as *mut dyn Read,
+            read: unsafe {
+                std::mem::transmute::<*mut (dyn Read + '_), *mut (dyn Read + 'static)>(input)
+            },
         };
 
         unsafe {


### PR DESCRIPTION
Hi there o/

I'm a member of the Rust Language Types Team; as part of stabilizing the `arbitrary_self_types` and `derive_coerce_pointee` features we may need to change what raw pointer casts are legal (rust-lang/rust#136702). Specifically, casting `*const dyn Trait + 'a` to `*const dyn Trait + 'b` where it is not able to be proven that `'a` outlives `'b` may become an error.

Without going into too much detail, the justification for this change be that casting trait object's lifetime bound to a lifetime that lives for a longer time could invalidate the VTable of the trait object, allowing for dispatching to methods that should not be callable. See this example from the linked issue:
```rust
#![forbid(unsafe_code)]
#![feature(arbitrary_self_types, derive_coerce_pointee)]

use std::any::TypeId;
use std::marker::{CoercePointee, PhantomData};

#[derive(CoercePointee)]
#[repr(transparent)]
struct SelfPtr<T: ?Sized>(*const T);

impl<T: ?Sized> std::ops::Deref for SelfPtr<T> {
    type Target = T;
    fn deref(&self) -> &T {
        panic!("please don't call me, I just want the `Receiver` impl!");
    }
}

trait GetTypeId {
    fn get_type_id(self: SelfPtr<Self>) -> TypeId
    where
        Self: 'static;
}

impl<T: ?Sized> GetTypeId for PhantomData<T> {
    fn get_type_id(self: SelfPtr<Self>) -> TypeId
    where
        Self: 'static,
    {
        TypeId::of::<T>()
    }
}

// no `T: 'static` bound necessary
fn type_id_of<T: ?Sized>() -> TypeId {
    let ptr = SelfPtr(
        &PhantomData::<T> as *const (dyn GetTypeId + '_) as *const (dyn GetTypeId + 'static),
    );
    ptr.get_type_id()
}

``` 

Unfortunately, going through the usual "future compatibility warning" process may turn out to not be possible as checking lifetime constraints without emitting an error is prohibitively difficult to do in the implementation of the borrow checker. This means that you may wind up never receiving a FCW and its associated grace period to update your code to be compatible with the new rules.

I have attempted to update your codebase to the new rules for you so that it will still compile if we make this change. I hope this potential breakage won't cause you too much trouble and that you might even find the post-migration code to be better than how it was previously :-)

Finally, it has not been decided yet whether we are to go through with this breaking change. If you feel that your code should continue to work as-is then please let me know and we'll try to take that into account when evaluating whether to go through with this breakage. Additionally if you have any questions about why this change is required please let me know and I'll do my best to further explain the justification.